### PR TITLE
Fix path to curator binary (take two)

### DIFF
--- a/bin/curator-cron
+++ b/bin/curator-cron
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CURATOR_CLI=${CURATOR_CLI:-/usr/bin/curator_cli}
+CURATOR_CLI=${CURATOR_CLI:-/usr/bin/curator}
 PERIODIC_FILE=/etc/periodic/daily/50-curator
 # save provided arguments
 cat > $PERIODIC_FILE <<EOF


### PR DESCRIPTION
This time using the correct merge base!

```
joh@ibuti:efk (fix-20170620)$ kubectl exec -ti elasticsearch-curator-3603845840-wq5q5 sh
/ # cat /etc/periodic/daily/50-curator 
#!/bin/sh

/usr/bin/curator --logformat logstash --host elasticsearch-logging.kube-system.svc.cluster.local delete indices --older-than 23 --time-unit days --timestring %Y.%m.%d
/ # /usr/bin/curator --logformat logstash --host elasticsearch-logging.kube-system.svc.cluster.local delete indices --older-than 23 --time-unit days --timestring %Y.%m.%d
{"@timestamp": "2017-06-21T15:29:11.823Z", "function": "indices", "linenum": 62, "loglevel": "INFO", "message": "Job starting: delete indices", "name": "curator.cli.index_selection"}
{"@timestamp": "2017-06-21T15:29:12.123Z", "function": "indices", "linenum": 112, "loglevel": "INFO", "message": "Pruning Kibana-related indices to prevent accidental deletion.", "name": "curator.cli.index_selection"}
{"@timestamp": "2017-06-21T15:29:12.123Z", "function": "indices", "linenum": 149, "loglevel": "INFO", "message": "Action delete will be performed on the following indices: [u'logstash-2017.05.29']", "name": "curator.cli.index_selection"}
{"@timestamp": "2017-06-21T15:29:12.126Z", "function": "delete_indices", "linenum": 21, "loglevel": "INFO", "message": "Deleting indices as a batch operation:", "name": "curator.api.delete"}
{"@timestamp": "2017-06-21T15:29:12.220Z", "function": "delete_indices", "linenum": 23, "loglevel": "INFO", "message": "---deleting index logstash-2017.05.29", "name": "curator.api.delete"}
{"@timestamp": "2017-06-21T15:29:12.736Z", "function": "exit_msg", "linenum": 67, "loglevel": "INFO", "message": "Job completed successfully.", "name": "curator.cli.utils"}
```