### PR TITLE
Update 5.5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN apk --update add python py-pip curl && \
-    pip install elasticsearch-curator==5.4.1 && \
+    pip install elasticsearch-curator==5.5.4 && \
     mkdir -p /root/.curator/
 
 COPY ./bin /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ you would run `curator` command directly:
 You have to provide your curator job settings in a action file. Samples can be found here `https://www.elastic.co/guide/en/elasticsearch/client/curator/current/actionfile.html`
 
 ```
-docker run --rm traumfewo/docker-curator-cron:5.4.1 < path to ACTION_FILE.YML>'
+docker run --rm traumfewo/docker-curator-cron:5.4.1 <path to ACTION_FILE.YML>
 ```

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ Dockerized version of [Elasticsearch Curator](https://github.com/elastic/curator
 
 ## Compatibility Matrix
 
-|Version/Branch | ES 1.x   | AWS ES 1.x | ES 2.x   | AWS ES 2.x | ES 5.x   | AWS ES 5.x | ES 6.x |
-|--------|----------|------------|----------|------------|----------|------------|------------|
-|    3.x   |    yes   |     yes*   |   yes    |     yes*   |   no     |     no     |     no     |
-|    4.x   |    no    |     no     |   yes    |     no     |   yes    |     no     |     no     |
-|    5.x   |    no    |     no     |   no     |     no     |   yes    |     yes*   |     no     |
-|    5.4+  |    no    |     no     |   no     |     no     |   yes    |     yes*   |     yes    |
+|Version/Branch | ES 1.x   | AWS ES 1.x | ES 2.x   | AWS ES 2.x | ES 5.x   | AWS ES 5.x | ES 6.x     |
+|---------------|----------|------------|----------|------------|----------|------------|------------|
+|  3.x          |    yes   |     yes*   |   yes    |     yes*   |   no     |     no     |     no     |
+|  4.x          |    no    |     no     |   yes    |     no     |   yes    |     no     |     no     |
+|  5.x          |    no    |     no     |   no     |     no     |   yes    |     yes*   |     no     |
+|  5.4          |    no    |     no     |   no     |     no     |   yes    |     yes*   |     yes    |
+|  5.5          |    no    |     no     |   no     |     no     |   yes    |     yes*   |     yes    |
 
 \* It appears that AWS ES does not allow access to the snapshot status endpoint for either 1.x or 2.x versions. This prevents Curator 3 from being used to make snapshots.
 
@@ -29,5 +30,5 @@ you would run `curator` command directly:
 You have to provide your curator job settings in a action file. Samples can be found here `https://www.elastic.co/guide/en/elasticsearch/client/curator/current/actionfile.html`
 
 ```
-docker run --rm traumfewo/docker-curator-cron:5.4.1 <path to ACTION_FILE.YML>
+docker run --rm traumfewo/docker-curator-cron:5.5 <path to ACTION_FILE.YML>
 ```

--- a/bin/curator-cron
+++ b/bin/curator-cron
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 CURATOR_CLI=${CURATOR_CLI:-/usr/bin/curator}
->>>>>>> 5.4
 PERIODIC_FILE=/etc/periodic/daily/50-curator
 # save provided arguments
 cat > $PERIODIC_FILE <<EOF


### PR DESCRIPTION
Removes line in curator cron script which was broken. Updates curator to 5.5.4 to support ES v6. Maybe we should add a build job for Dockerhub.